### PR TITLE
Add prettier rules

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   semi: false,
   singleQuote: true,
+  tabWidth: 2,
   plugins: [require('prettier-plugin-tailwindcss')],
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -2,5 +2,6 @@ module.exports = {
   semi: false,
   singleQuote: true,
   tabWidth: 2,
+  trailingComma: 'all',
   plugins: [require('prettier-plugin-tailwindcss')],
 }


### PR DESCRIPTION
I'm going to try to automate the version bump and release process. To warrant this I need to have something releasable. So I added these 2 rules. After merge I'll experiment with bump/ release PR.

The tabs: 2 will most of the time be implemented already because of the .editorconfig. But there is not way to make sure .editorconfig is the same between projects. So this is safer. 

The trailingComma: 'all' will also add commas in places older 'es5' browser don't support. 'es5' is Prettier default to support older browsers like ie11, but we don't support those anymore anyway.