### PR TITLE
Add npm-version bump github action

### DIFF
--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -1,0 +1,29 @@
+name: Bump NPM version
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type (one of): patch, minor, major, prepatch, preminor, premajor, prerelease'
+        required: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Git configuration
+        run: |
+          git config --global user.email "<>"
+          git config --global user.name "GitHub Actions Bot"
+
+      - name: Bump version
+        run: npm version ${{ github.event.inputs.release-type }}
+
+      - name: Push changes to repository
+        run: git push origin && git push --tags

--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -26,4 +26,4 @@ jobs:
         run: npm version ${{ github.event.inputs.release-type }}
 
       - name: Push changes to repository
-        run: git push origin && git push --tags
+        run: git push https://${{ secrets.DEPLOYER_RELEASE_TOKEN }}:x-oauth-basic@github.com/leukeleu/prettier-config/.git main && git push https://${{ secrets.DEPLOYER_RELEASE_TOKEN }}:x-oauth-basic@github.com/leukeleu/prettier-config/.git --tags

--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Git configuration
         run: |
-          git config --global user.email "<>"
-          git config --global user.name "GitHub Actions Bot"
+          git config user.name "Leukeleu Deployer"
+          git config user.email "deployer@leukeleu.nl"
 
       - name: Bump version
         run: npm version ${{ github.event.inputs.release-type }}


### PR DESCRIPTION
This action will bump the version using 'npm version'. First you'll get a prompt to what version-type you want to bump. Then it will do so, commit and push + push the tags. 

See branch fork for tests https://github.com/twesterhuis/prettier-config-actions/actions.

Will add a NPM publish workflow after this.