### PR TITLE
Add npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,20 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Tested it in https://github.com/leukeleu/ci-npm-publish-test/actions/workflows/npm-publish.yml. Results in new NPM releases https://www.npmjs.com/package/@leukeleu/ci-npm-publish-test. 

Approach is similar to https://github.com/leukeleu/leukeleu-django-checks/blob/main/.github/workflows/python-publish.yml.

Would like to discuss security with @wadevries and/ or @dbunskoek since we need to generate a token on NPM.