### PR TITLE
set prettier as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leukeleu/prettier-config",
   "repository": "https://github.com/leukeleu/prettier-config.git",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Reusable Prettier config for Leukeleu projects",
   "main": "index.js",
   "scripts": {
@@ -13,8 +13,10 @@
     "prettier"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "prettier": "3.1.1"
+  },
   "dependencies": {
-    "prettier": "3.1.1",
     "prettier-plugin-tailwindcss": "0.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leukeleu/prettier-config",
   "repository": "https://github.com/leukeleu/prettier-config.git",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "Reusable Prettier config for Leukeleu projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Because currently Prettier only exists as a dependency to this config, projects that in turn depend on _this_ package don't need to install the proper version of Prettier. 

This works out fine when Prettier didn't previously exist in whatever project you use this config for (or when the version being used is correct coincidentally), but when the project previously used a different older version of Prettier, this setup will break because it will use that older version. 

This can be fixed by re-making the package-lock.json in every project where this occurs, but it's not an intuitive or very sustainable way of handling this issue. Therefore I propose adding the correct version of Prettier as a peer dependency to this package, so whenever we install it somewhere, we'll be notified by npm (or other package managers) to install the correct version of Prettier. 