### PR TITLE
prevent html closing tag to be placed on newline

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,5 +2,6 @@ module.exports = {
   semi: false,
   singleQuote: true,
   tabWidth: 2,
+  htmlWhitespaceSensitivity: 'ignore',
   plugins: [import('prettier-plugin-tailwindcss')],
 }


### PR DESCRIPTION
https://trungk18.com/experience/prettier-prevent-html-closing-tag-new-line/

From this:
```
<span>
  I accept the
  <a class="underline" routerLink="/tnc"
    >Our terms and conditions</a
  >
</span>
```
To:
```
<span>
  I accept the
  <a class="underline" routerLink="/tnc">
    Our terms and conditions
  </a>
</span>
```