### PR TITLE
Set trailingcomma's to ES5

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,4 +3,5 @@ module.exports = {
   singleQuote: true,
   tabWidth: 2,
   plugins: [import('prettier-plugin-tailwindcss')],
+  trailingComma: 'es5',
 }


### PR DESCRIPTION
Since prettier changed their default setting to `all` instead of `es5`, we have to specify `es5` now.

See: https://prettier.io/docs/en/options.html#trailing-commas